### PR TITLE
Policy to String conversion and minor typo fixes

### DIFF
--- a/src/main/java/sg/edu/ntu/sce/sands/crypto/DCPABETool.java
+++ b/src/main/java/sg/edu/ntu/sce/sands/crypto/DCPABETool.java
@@ -23,7 +23,7 @@ public class DCPABETool {
 				decrypt(args) ||
 				globalsetup(args) ||
 				keygen(args) ||
-				authhoritySetup(args) ||
+				authoritySetup(args) ||
 				check(args)) {
         } else {
             help();
@@ -31,7 +31,7 @@ public class DCPABETool {
 	}
 
     // asetup <authority name> <gpfile> <authorityfileS> <authorityfileP> <attribute 1 > ... <attribute n>
-    private static boolean authhoritySetup(String[] args) {
+    private static boolean authoritySetup(String[] args) {
         if (!args[0].equals("asetup") || args.length <= 5) return false;
 
 		try {
@@ -243,6 +243,6 @@ public class DCPABETool {
 		System.out.println("asetup <authority name> <gpfile> <authorityfileS> <authorityfileP> <attribute 1 > ... <attribute n>");
 		System.out.println("keyGen <username> <attribute name> <gpfile> <authorityfileS> <keyfile>");
 		System.out.println("enc <resource file> <policy> <ciphertext> <gpfile> <authorityfileP 1> ... <authorityfileP n>");
-		System.out.println("dec <ciphertext> <resource file> <gpfile> <keyfile 1> <keyfile 2>");
+		System.out.println("dec <username> <ciphertext> <resource file> <gpfile> <keyfile 1> <keyfile 2>");
 	}
 }

--- a/src/main/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructure.java
+++ b/src/main/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructure.java
@@ -258,8 +258,11 @@ public class AccessStructure implements Serializable {
         if (builder.length() != 0) builder.append(" ");
 
         if (node instanceof InternalNode) {
+            builder.append(node.getName());
             toString(builder, ((InternalNode) node).getLeft());
             toString(builder, ((InternalNode) node).getRight());
+        } else {
+            builder.append(node.getName());
         }
     }
 

--- a/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/SerializationTest.java
+++ b/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/SerializationTest.java
@@ -47,7 +47,7 @@ public class SerializationTest {
 
     @Test
     public void serializeAccessStructure() throws Exception {
-        AccessStructure ac = AccessStructure.buildFromPolicy("a b c and or");
+        AccessStructure ac = AccessStructure.buildFromPolicy("or and a b c");
 
         String serializedValue = mapper.writeValueAsString(ac);
 

--- a/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructureTest.java
+++ b/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructureTest.java
@@ -1,0 +1,29 @@
+package sg.edu.ntu.sce.sands.crypto.dcpabe.ac;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import sg.edu.ntu.sce.sands.crypto.dcpabe.ac.AccessStructure;
+
+import static org.junit.Assert.assertEquals;
+
+public class AccessStructureTest {
+    private AccessStructure arho;
+    private static String policy;
+
+    @BeforeClass
+    public static void init() {
+        policy = "and A or D and C B";
+    }
+
+    @Before
+    public void setUp() {        
+        arho = AccessStructure.buildFromPolicy(policy);
+    }
+
+    @Test
+    public void testPolicyToStringConversion() throws Exception{
+        String recoveredPolicy = arho.toString();
+        assertEquals(policy, recoveredPolicy);
+    }
+}


### PR DESCRIPTION
Fix toString() funcion in AccessStructure and fix typos on help() and authoritySetup() functions in DCPABETool.

While analyzing your code, I fixed some things on a local repository, so I guessed I could also contribute to your code as well. Please reply if the code needs any change for proper merging.

Best regards.