### PR TITLE
Add support to infix notation in access policies

### DIFF
--- a/src/main/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructure.java
+++ b/src/main/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructure.java
@@ -225,12 +225,70 @@ public class AccessStructure implements Serializable {
         }
     }
 
+    /**
+     * Generates and stores in memory the binary tree representation of a policy.
+     * The tree is built with instances of TreeNode child classes.
+     *
+     * @param policy a policy written as a monotonic boolean formula over attributes
+     *               labels. The policy can be written in both infix or polish
+     *               notation.
+     */
     private void generateTree(String policy) {
+        String[] policyParts;
         partsIndex = -1;
 
-        String[] policyParts = policy.split("\\s+");
-
+        // checking if the policy is in an infix or a prefix notation.
+        if (policy.toLowerCase().indexOf("and") > 0 && policy.toLowerCase().indexOf("or") > 0) {
+            policy = policy.replace("(", "( ").replace(")", " )");
+            policyParts = infixNotationToPolishNotation(policy.split("\\s+"));
+        } else {
+            policyParts = policy.split("\\s+");
+        }
         policyTree = generateTree(policyParts);
+    }
+
+    /**
+     * Finds the Normal Polish Notation of a policy in its infix form, by
+     * implementing the Shunting-yard Algorithm (https://w.wiki/BmY)
+     *
+     * @param policy a array of tokens of a policy written in its infix form.
+     *               Parentheses must be represented as whole tokens.
+     * @return a array of tokens of the same policy in its Normal Polish Notation.
+     */
+    private String[] infixNotationToPolishNotation(String[] policy) {
+        Map<String, Integer> precedence = new HashMap<>();
+        precedence.put("and", 2);
+        precedence.put("or", 1);
+        precedence.put("(", 0);
+
+        Stack<String> rpn = new Stack<String>(); //rpn stands for Reverse Polish Notation
+        Stack<String> operators = new Stack<String>();
+
+        for (String token : policy) {
+            if (token.equals("(")) {
+                operators.push(token);
+            } else if (token.equals(")")) {
+                while (!operators.peek().equals("(")) {
+                    rpn.add(operators.pop());
+                }
+                operators.pop();
+            } else if (precedence.containsKey(token)) {
+                while (!operators.empty() && precedence.get(token) <= precedence.get(operators.peek())) {
+                    rpn.add(operators.pop());
+                }
+                operators.push(token);
+            } else {
+                rpn.add(token);
+            }
+        }
+        while (!operators.isEmpty()) {
+            rpn.add(operators.pop());
+        }
+
+        // reversing the result to obtain Normal Polish Notation
+        List<String> polishNotation = new ArrayList<String>(rpn);
+        Collections.reverse(polishNotation);
+        return polishNotation.toArray(new String[] {});
     }
 
     public void printMatrix() {

--- a/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructureTest.java
+++ b/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructureTest.java
@@ -1,7 +1,6 @@
 package sg.edu.ntu.sce.sands.crypto.dcpabe.ac;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import sg.edu.ntu.sce.sands.crypto.dcpabe.ac.AccessStructure;
 
@@ -13,13 +12,27 @@ public class AccessStructureTest {
 
     @Before
     public void setUp() {
-        policy = "and A or D and C B";
+        policy = "and or D and C B A";
         arho = AccessStructure.buildFromPolicy(policy);
     }
 
     @Test
-    public void testPolicyToStringConversion() throws Exception{
+    public void testPolicyToStringConversion() throws Exception {
         String recoveredPolicy = arho.toString();
         assertEquals(policy, recoveredPolicy);
+    }
+
+    @Test
+    public void testInfixToPolishNotationSimpleConversion() {
+        String infixNotation = "a";
+        AccessStructure arhoInfix = AccessStructure.buildFromPolicy(infixNotation);
+        assertEquals(infixNotation, arhoInfix.toString());
+    }
+
+    @Test
+    public void testInfixToPolishNotationConversionWithParentheses() {
+        String infixNotation = "A and (B and C or D)";
+        AccessStructure arhoInfix = AccessStructure.buildFromPolicy(infixNotation);
+        assertEquals(policy, arhoInfix.toString());
     }
 }


### PR DESCRIPTION
Hi @stefano81,

Regarding #2 , I added support for access policies written in infix notation. Its better for new users to figure out what is happening and to prototype new testing policies faster. I added javadocs and tests.

It justs add a step before tree generation, parsing a policy to polish notation if needed..

I changed the default policy for tests in [AccessStructureTest](https://github.com/stefano81/dcpabe/blob/4c8d506ca7b49c91048f9965c33a760c93c3de91/src/test/java/sg/edu/ntu/sce/sands/crypto/dcpabe/ac/AccessStructureTest.java#L16), as the attribute A was misplaced ahead of where it should be, not matching the result of the Shunting-yard algorithm I used here, so I put it on the end of the policy to make my test pass.